### PR TITLE
Fix Rails 6 deprecation warnings

### DIFF
--- a/lib/vanity/commands/report.rb
+++ b/lib/vanity/commands/report.rb
@@ -78,7 +78,7 @@ module Vanity
       # Generate an HTML report. Outputs to the named file, or stdout with no
       # arguments.
       def report(output = nil)
-        html = render(Vanity.template("report"),
+        html = render(Vanity.template("_report.erb"),
           :experiments=>Vanity.playground.experiments,
           :experiments_persisted=>Vanity.playground.experiments_persisted?,
           :metrics=>Vanity.playground.metrics

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -251,7 +251,7 @@ module Vanity
       def vanity_js
         return if Vanity.context.vanity_active_experiments.nil? || Vanity.context.vanity_active_experiments.empty?
         javascript_tag do
-          render :file => Vanity.template("_vanity"), :formats => [:js]
+          render :file => Vanity.template("_vanity.js.erb"), :formats => [:js]
         end
       end
 
@@ -349,7 +349,7 @@ module Vanity
     # Step 3: Open your browser to http://localhost:3000/vanity
     module Dashboard
       def index
-        render :file=>Vanity.template("_report"),:content_type=>Mime[:html], :locals=>{
+        render :file=>Vanity.template("_report.erb"),:content_type=>Mime[:html], :locals=>{
           :experiments=>Vanity.playground.experiments,
           :experiments_persisted=>Vanity.playground.experiments_persisted?,
           :metrics=>Vanity.playground.metrics
@@ -357,7 +357,7 @@ module Vanity
       end
 
       def participant
-        render :file=>Vanity.template("_participant"), :locals=>{:participant_id => params[:id], :participant_info => Vanity.playground.participant_info(params[:id])}, :content_type=>Mime[:html]
+        render :file=>Vanity.template("_participant.erb"), :locals=>{:participant_id => params[:id], :participant_info => Vanity.playground.participant_info(params[:id])}, :content_type=>Mime[:html]
       end
 
       def complete
@@ -367,36 +367,36 @@ module Vanity
         # make the user confirm before completing an experiment
         if confirmed && confirmed.to_i==alt.id && exp.active?
           exp.complete!(alt.id)
-          render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+          render :file=>Vanity.template("_experiment.erb"), :locals=>{:experiment=>exp}
         else
           @to_confirm = alt.id
-          render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+          render :file=>Vanity.template("_experiment.erb"), :locals=>{:experiment=>exp}
         end
       end
 
       def disable
         exp = Vanity.playground.experiment(params[:e].to_sym)
         exp.enabled = false
-        render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+        render :file=>Vanity.template("_experiment.erb"), :locals=>{:experiment=>exp}
       end
 
       def enable
         exp = Vanity.playground.experiment(params[:e].to_sym)
         exp.enabled = true
-        render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+        render :file=>Vanity.template("_experiment.erb"), :locals=>{:experiment=>exp}
       end
 
       def chooses
         exp = Vanity.playground.experiment(params[:e].to_sym)
         exp.chooses(exp.alternatives[params[:a].to_i].value)
-        render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+        render :file=>Vanity.template("_experiment.erb"), :locals=>{:experiment=>exp}
       end
 
       def reset
         exp = Vanity.playground.experiment(params[:e].to_sym)
         exp.reset
         flash[:notice] = I18n.t 'vanity.experiment_has_been_reset', name: exp.name
-        render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+        render :file=>Vanity.template("_experiment.erb"), :locals=>{:experiment=>exp}
       end
 
       include AddParticipant

--- a/lib/vanity/templates/_experiment.erb
+++ b/lib/vanity/templates/_experiment.erb
@@ -26,7 +26,7 @@
   </p>
 <% end %>
 <a class="button reset" title="<%= I18n.t('vanity.reset') %>" href="#" data-id="<%= experiment.id %>" data-url="<%= url_for(:action=>:reset, :e=>experiment.id) %>"><%= I18n.t 'vanity.reset' %></a>
-<%= render :file => Vanity.template("_" + experiment.type), :locals => {:experiment => experiment} %>
+<%= render :file => Vanity.template("_" + experiment.type + ".erb"), :locals => {:experiment => experiment} %>
 <p class="meta">
   <%= I18n.t('vanity.started_at', :timestamp=>I18n.l(experiment.created_at, :format=>'%a, %b %d')) %>
   <%= ' | '+I18n.t('vanity.completed_at', :timestamp=>I18n.l(experiment.completed_at, :format=>'%a, %b %d')) unless experiment.active? %>

--- a/lib/vanity/templates/_experiments.erb
+++ b/lib/vanity/templates/_experiments.erb
@@ -1,7 +1,7 @@
 <ul class="experiments">
   <% experiments.sort_by{|id, experiment| experiment.created_at}.sort_by{ |id, experiment| experiment.name }.reverse.each do |id, experiment| %>
     <li class="experiment <%= experiment.type %>" id="experiment_<%=vanity_h id.to_s %>">
-    <%= render :file => Vanity.template("_experiment"), :locals => { :id => id, :experiment => experiment } %>
+    <%= render :file => Vanity.template("_experiment.erb"), :locals => { :id => id, :experiment => experiment } %>
     </li>
   <% end %>
 </ul>

--- a/lib/vanity/templates/_metrics.erb
+++ b/lib/vanity/templates/_metrics.erb
@@ -1,7 +1,7 @@
 <ul class="metrics">
   <% metrics.sort_by { |id, metric| metric.name }.each do |id, metric| %>
     <li class="metric" id="metric_<%= id %>">
-      <%= render :file=>Vanity.template("_metric"), :locals=>{:id=>id, :metric=>metric} %>
+      <%= render :file=>Vanity.template("_metric.erb"), :locals=>{:id=>id, :metric=>metric} %>
     </li>
   <% end %>
 </ul>

--- a/lib/vanity/templates/_report.erb
+++ b/lib/vanity/templates/_report.erb
@@ -22,12 +22,12 @@
       <% if experiments_persisted %>
         <% if experiments.present? %>
           <h2><%= I18n.t 'vanity.experiments' %></h2>
-          <%= render :file=>Vanity.template("_experiments"), :locals=>{:experiments=>experiments} %>
+          <%= render :file=>Vanity.template("_experiments.erb"), :locals=>{:experiments=>experiments} %>
         <% end %>
 
         <% unless metrics.empty? %>
           <h2><%= I18n.t 'vanity.metrics' %></h2>
-          <%= render :file=>Vanity.template("_metrics"), :locals=>{:metrics=>metrics, :experiments=>experiments} %>
+          <%= render :file=>Vanity.template("_metrics.erb"), :locals=>{:metrics=>metrics, :experiments=>experiments} %>
         <% end %>
       <% else %>
         <div class="alert persistance">


### PR DESCRIPTION
During a recent Rails 6 upgrade Seb noticed that the `ahoy_js` view helper
was emitting a deprecation warning. It turns out this was due to the gem
calling `render file:` with incomplete file paths (they were missing the
file extension) [1].

In Rails 6 [2], this option now requires that you provide the full path
to the file.

In order to fix this these deprecation warnings I have updated all calls
to `Vanity.template` so that they now include the file extension.

Ideally I would have liked to abstract the code handling extensions down
into `Vanity.template` but since this extension can vary I thought it
was best to be explicit and just pass it in as part of the filename.

[1] https://github.com/rails/rails/blob/03d32ca23b80e74bb3bc385a29c8f44bb60a7b8c/actionview/lib/action_view/renderer/template_renderer.rb#L29
[2] https://github.com/rails/rails/commit/c7820d8124c854760a4d288334f185de2fb99446